### PR TITLE
Use `get_virtual_package_records` instead of deprecated `get_virtual_packages`.

### DIFF
--- a/conda_anaconda_telemetry/hooks.py
+++ b/conda_anaconda_telemetry/hooks.py
@@ -76,8 +76,8 @@ def get_virtual_packages() -> tuple[str, ...]:
     Uses the ``conda.base.context.context`` object to retrieve registered virtual packages
     """
     return tuple(
-        f"{package.name}.{package.version}.{package.build}"
-        for package in context.plugin_manager.get_virtual_packages()
+        f"{package.name}={package.version}={package.build}"
+        for package in context.plugin_manager.get_virtual_package_records()
     )
 
 


### PR DESCRIPTION
Also use equal sign for string concatenation instead of dot given that's the precedence.

The `get_virtual_package_records` API was recently added as part of https://github.com/conda/conda/pull/13880.