### PR TITLE
Changing pre-commit to not mess with years in license blurb

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
       # auto inject license blurb
       - id: insert-license
         files: \.py$
-        args: [--license-filepath, .github/disclaimer.txt, --no-extra-eol, --use-current-year]
+        args: [--license-filepath, .github/disclaimer.txt, --no-extra-eol]
   - repo: https://github.com/adamchainz/blacken-docs
     rev: 1.19.1
     hooks:


### PR DESCRIPTION
Let's not update the years in our Python files. This resolves an issue with failing builds on these pull requests:

- https://github.com/anaconda/conda-anaconda-telemetry/pull/86
- https://github.com/anaconda/conda-anaconda-telemetry/pull/85