### PR TITLE
Update instructions for disabling the plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,13 @@ conda install --name base conda-anaconda-telemetry
 
 ## Disabling
 
-To disable this plugin, you can either add the following to your `.condarc` file:
+To disable this plugin, you can either use the `conda config` command:
 
-```yaml
-plugins:
-  anaconda_telemetry: false
+```
+conda config --set plugins.anaconda_telemetry false
 ```
 
-Or remove it from your base environment:
+Or remove this plugin from your base environment:
 
 ```commandline
 conda remove --name base conda-anaconda-telemetry


### PR DESCRIPTION
Since we've written this README, we've added the ability to update plugin settings via `conda config --set`. Because this way is simpler (i.e. requires less steps), we should be encouraging it instead.